### PR TITLE
gh #41 add missing secondary_mixer in MTK player config

### DIFF
--- a/configs/utPlayerConfig.yml
+++ b/configs/utPlayerConfig.yml
@@ -62,3 +62,4 @@ mediatek:
     play_command: gst-play-1.0
     stop_command: "\x03" # CNTRL-C
     primary_mixer_input_config: ""
+    secondary_mixer_input_config: ""


### PR DESCRIPTION
secondary_mixer is missing in utPlayer config file for MTK
L3 dsAudio tests fail to initiate with error secondary_mixer

Adding secondary_mixer_input_config: "" to MTK utPlayer config file will run and play streams for L3 dsAudio tests.